### PR TITLE
#78. Fix uui Dialog.svelte: reset the document.body overflow behavior…

### DIFF
--- a/uui/src/lib/Dialog/Dialog.svelte
+++ b/uui/src/lib/Dialog/Dialog.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import Box from '../Box/box.svelte';
-  import { onMount } from 'svelte';
+  import { onDestroy, onMount } from 'svelte';
 
   // vars
   let scrollBehavior: string;
@@ -18,6 +18,9 @@
   onMount(() => {
     documentRef = document;
     scrollBehavior = documentRef.body.style.overflow;
+  });
+  onDestroy(() => {
+    document.body.style.overflow === scrollBehavior;
   });
 
   // Watch


### PR DESCRIPTION
… onDestroy to prevent overflow hidden from being retained when using goto to navigate away.