### PR TITLE
#87 add playwright tests

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,4 +4,4 @@
 npm run format
 npm run lint
 npm run check
-npm run test:unit
+npm run test

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "package": "npm run build -w uui",
     "build": "npm run build -w website",
     "check": "npm run check --workspaces",
+    "test": "npm run test:unit:uui && npm run test -w website",
     "test:unit": "npm run test:unit --workspaces -- --passWithNoTests",
     "test:unit:uui": "npm run test:unit -w uui",
     "test:unit:web": "npm run test:unit -w website",

--- a/website/jest.config.js
+++ b/website/jest.config.js
@@ -9,5 +9,6 @@ export default {
       }
     ]
   },
+  modulePathIgnorePatterns: ['/playwright-tests/'],
   moduleFileExtensions: ['js', 'ts', 'svelte']
 };

--- a/website/package.json
+++ b/website/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "dev": "vite dev --host",
     "build": "vite build",
+    "preview": "vite preview",
     "test": "playwright test",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "test:component": "jest",

--- a/website/playwright-tests/website.spec.ts
+++ b/website/playwright-tests/website.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, Page, Locator } from '@playwright/test';
-
+test.describe.configure({ mode: 'parallel' });
 test.describe('unicorn ui website e2e tests', () => {
   test.beforeEach(async ({ page }) => {
     page.on('pageerror', (err) => console.log(err.message));
@@ -17,6 +17,7 @@ test.describe('unicorn ui website e2e tests', () => {
     context,
     page
   }) => {
+    test.slow();
     for (const link of await page.getByRole('link').all()) {
       const pageForLink = await context.newPage();
       await pageForLink.goto('http://localhost:4173');

--- a/website/playwright-tests/website.spec.ts
+++ b/website/playwright-tests/website.spec.ts
@@ -1,4 +1,19 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, Page, Locator } from '@playwright/test';
+
+const testLink = async (linkLocator: Locator, page: Page): Promise<void> => {
+  const linkUrl = await linkLocator.getAttribute('href');
+  if (linkUrl!.includes('https://')) return;
+  const pageNav = page.waitForNavigation({ url: `**${linkUrl}` });
+  linkLocator.click();
+  await pageNav;
+  expect(page.url()).toContain(linkUrl);
+};
+
+const resetToHome = async (page: Page) => {
+  const pageNav = page.waitForNavigation({ url: `**/` });
+  page.getByText(/home/i).click();
+  await pageNav;
+};
 
 test.describe('unicorn ui website e2e tests', () => {
   test.beforeEach(async ({ page }) => {
@@ -9,12 +24,13 @@ test.describe('unicorn ui website e2e tests', () => {
     expect(page.url()).toEqual('http://localhost:4173/');
     expect(page.getByText('Unicorn UI')).toBeTruthy();
     expect(page.getByText('Installation')).toBeTruthy();
+    expect(page.getByText(/github/i)).toBeTruthy();
   });
 
-  test('nav to /theme', async ({ page }) => {
-    const pageNav = page.waitForNavigation({ url: '**/theme' });
-    page.getByText(/^theme$/i).click();
-    await pageNav;
-    expect(page.url()).toContain('/theme');
+  test('test links', async ({ page }) => {
+    for (const link of await page.getByRole('link').all()) {
+      await testLink(link, page);
+      await resetToHome(page);
+    }
   });
 });

--- a/website/playwright-tests/website.spec.ts
+++ b/website/playwright-tests/website.spec.ts
@@ -1,21 +1,20 @@
-import { test, expect} from '@playwright/test';
+import { test, expect } from '@playwright/test';
 
 test.describe('unicorn ui website e2e tests', () => {
-    test.beforeEach(async ({page}) => {
-        await page.goto("http://localhost:4173");
-    })
+  test.beforeEach(async ({ page }) => {
+    await page.goto('http://localhost:4173');
+  });
 
-    test('load home page', async ({page}) => {
-        expect(page.url()).toEqual("http://localhost:4173/")
-        expect(page.getByText('Unicorn UI')).toBeTruthy();
-        expect(page.getByText('Installation')).toBeTruthy();
-    })
+  test('load home page', async ({ page }) => {
+    expect(page.url()).toEqual('http://localhost:4173/');
+    expect(page.getByText('Unicorn UI')).toBeTruthy();
+    expect(page.getByText('Installation')).toBeTruthy();
+  });
 
-    test('nav to /theme', async ({page}) => {
-        const pageNav =  page.waitForNavigation({ url: '**/theme' });
-        page.getByText(/^theme$/i).click();
-        await pageNav;
-        expect(page.url()).toContain('/theme');
-    })
-})
-
+  test('nav to /theme', async ({ page }) => {
+    const pageNav = page.waitForNavigation({ url: '**/theme' });
+    page.getByText(/^theme$/i).click();
+    await pageNav;
+    expect(page.url()).toContain('/theme');
+  });
+});

--- a/website/playwright-tests/website.spec.ts
+++ b/website/playwright-tests/website.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect} from '@playwright/test';
+
+test.describe('unicorn ui website e2e tests', () => {
+    test.beforeEach(async ({page}) => {
+        await page.goto("http://localhost:4173");
+    })
+
+    test('load home page', async ({page}) => {
+        expect(page.url()).toEqual("http://localhost:4173/")
+        expect(page.getByText('Unicorn UI')).toBeTruthy();
+        expect(page.getByText('Installation')).toBeTruthy();
+    })
+
+    test('nav to /theme', async ({page}) => {
+        const pageNav =  page.waitForNavigation({ url: '**/theme' });
+        page.getByText(/^theme$/i).click();
+        await pageNav;
+        expect(page.url()).toContain('/theme');
+    })
+})
+


### PR DESCRIPTION
- Initial addition of playwright tests. Minimal at the moment.
- Brings up questions:
  1. What types of actions do we really want to test with playwright versus what's already tested (or will be) with jest?
  2. What, if anything, are we allowed to add to code (i.e. roles, data-testid, etc...) to make targeting specific elements easier?
- Added modulePathIgnorePatterns to /website/jest.config.ts because "npm run test:unit" was trying to run playwright tests with jest.