### PR TITLE
#203 -- Missing Disabled Prop on TextField Example

### DIFF
--- a/uui/src/lib/TextField/TextField.svelte
+++ b/uui/src/lib/TextField/TextField.svelte
@@ -216,14 +216,14 @@
   // Disabled State Classes
   .mdc-text-field--disabled {
     @include mdc-text-field-disabled-outline-color(var(--disabled));
-    @include mdc-text-field-disabled-ink-color(var(--disabled));
-    @include mdc-text-field-disabled-label-color(var(--disabled));
+    @include mdc-text-field-disabled-ink-color(var(--on-disabled));
+    @include mdc-text-field-disabled-label-color(var(--on-disabled));
 
     &:not(.mdc-text-field--outlined) {
-      @include mdc-text-field-disabled-fill-color(var(--disabled));
-      @include mdc-text-field-disabled-bottom-line-color(var(--disabled));
-      @include mdc-text-field-disabled-ink-color(var(--on-disabled));
-      @include mdc-text-field-disabled-label-color(var(--on-disabled));
+      @include mdc-text-field-disabled-fill-color(var(--on-disabled));
+      @include mdc-text-field-disabled-bottom-line-color(var(--on-disabled));
+      @include mdc-text-field-disabled-ink-color(var(--disabled));
+      @include mdc-text-field-disabled-label-color(var(--disabled));
     }
   }
 

--- a/website/src/routes/text-field/+page.svelte
+++ b/website/src/routes/text-field/+page.svelte
@@ -54,7 +54,7 @@
           </div>
           <div class="labeled-example">
             <Typography variant="subtitle1">Disabled:</Typography>
-            <TextField label="Label" variant="outlined" color="primary" value="Value" />
+            <TextField label="Label" variant="outlined" color="primary" value="Value" disabled />
           </div>
           <div class="labeled-example">
             <Typography variant="subtitle1">Error:</Typography>


### PR DESCRIPTION
TextField example in docs was labeled as disabled but was missing the disabled prop and was therefore allowing input and interaction.